### PR TITLE
Fix LWP ... and things

### DIFF
--- a/SU/API/Icinga2.pm
+++ b/SU/API/Icinga2.pm
@@ -72,7 +72,7 @@ sub do_request {
     $request_url = "$self->{url}/${uri}";
 
     if ($params) {
-        $params      = encode_params($params);
+        $params      = _encode_params($params);
         $request_url = "$self->{url}/${uri}?$params";
     }
     my $req = HTTP::Request->new( $method => $request_url );
@@ -102,28 +102,12 @@ sub do_request {
     return;
 }
 
-sub encode_params {
-    my ($filter) = @_;
-    my @filter_array;
-    my @encoded_uri_array;
+sub _encode_params {
+    return join '&', map { _encode_param($_) } split /&/, shift;
+}
 
-    if ( $filter =~ /&/ ) {
-        @filter_array = split( '&', $filter );
-    }
-    else {
-        @filter_array = $filter;
-    }
-    for (@filter_array) {
-        if ( $_ =~ /=/ ) {
-            my ( $argument, $value ) = split( "=", $_ );
-            push( @encoded_uri_array,
-                join( "=", uri_escape($argument), uri_escape($value) ) );
-        }
-        else {
-            push( @encoded_uri_array, uri_escape($_) );
-        }
-    }
-    return join( "&", @encoded_uri_array );
+sub _encode_param {
+    return join '=', map { uri_escape( $_ ) } split /=/, shift;
 }
 
 {

--- a/SU/API/Icinga2.pm
+++ b/SU/API/Icinga2.pm
@@ -103,7 +103,7 @@ sub do_request {
 }
 
 sub encode_params {
-    my $filter = $_[0];
+    my ($filter) = @_;
     my @filter_array;
     my @encoded_uri_array;
 

--- a/SU/API/Icinga2.pm
+++ b/SU/API/Icinga2.pm
@@ -8,6 +8,7 @@ use HTTP::Request;
 use URI::Escape;
 use JSON;
 use Encode qw( encode_utf8 );
+use version 0.77; our $VERSION = version->declare('v0.1.0');
 
 sub new {
     my $class = shift;

--- a/SU/API/Icinga2.pm
+++ b/SU/API/Icinga2.pm
@@ -224,39 +224,10 @@ sub login {
     return $self->{logged_in};
 }
 
-sub logout {
-    my ($self) = @_;
-    $self->{logged_in} = undef;
-}
-
-sub request_code {
-    my ($self) = @_;
-    return $self->{res}->code;
-}
-
-sub request_status_line {
-    my ($self) = @_;
-    return $self->{res}->status_line;
-}
-
-sub logged_in {
-    my ($self) = @_;
-    return $self->{logged_in};
-}
-
-sub login_status {
-    my ($self) = @_;
-    return $self->{login_status};
-}
-
-sub DESTROY {
-    my ($self) = @_;
-    if ( $self->{ua} && $self->{logged_in} ) {
-        $self->logout();
-    }
-    elsif ( $self->{logged_in} ) {
-        warn "Automatic logout failed";
-    }
-}
+sub logout { shift->{logged_in} = undef; }
+sub request_code { return shift->{res}->code; }
+sub request_status_line { return shift->{res}->status_line; }
+sub logged_in { return shift->{logged_in}; }
+sub login_status { return shift->{login_status}; }
 
 1;

--- a/SU/API/Icinga2.pm
+++ b/SU/API/Icinga2.pm
@@ -14,6 +14,7 @@ use version 0.77; our $VERSION = version->declare('v0.1.0');
 
 sub new {
     my ($class, $hostname, $port, $path, $version, $insecure) = @_;
+    my $cafile;
 
     defined $hostname
         or croak "hostname argument is required";
@@ -25,6 +26,11 @@ sub new {
         $path = $args{path};
         $version = $args{version};
         $insecure = $args{insecure};
+
+        if(defined $args{cacert}) {
+            # Set ENV variable in case we're using Net::SSL for LWP's HTTPS
+            $cafile = $ENV{HTTPS_CA_FILE} = $args{cacert};
+        }
     }
 
     my $self  = bless {
@@ -47,6 +53,8 @@ sub new {
                 # Don't verify certs with either SSL module used by LWP
                 verify_hostname => 0,
                 SSL_verify_callback => sub { 1 },
+                # Set ca_file for IO::Socket::SSL
+                defined $cafile ? ( SSL_ca_file => $cafile) : (),
             },
         ) : (),
     );

--- a/SU/API/Icinga2.pm
+++ b/SU/API/Icinga2.pm
@@ -68,13 +68,9 @@ sub new {
 sub do_request {
     my ( $self, $method, $uri, $params, $data, $plaintext ) = @_;
 
-    my $request_url;
-    $request_url = "$self->{url}/${uri}";
+    my $request_url = "$self->{url}/$uri";
+    $request_url .= '?' . _encode_params($params) if $params;
 
-    if ($params) {
-        $params      = _encode_params($params);
-        $request_url = "$self->{url}/${uri}?$params";
-    }
     my $req = HTTP::Request->new( $method => $request_url );
 
     if ($data) {
@@ -193,11 +189,10 @@ sub _encode_param {
 sub login {
     my ( $self, $username, $password ) = @_;
 
-    $self->{username} = $username;
-    $self->{password} = $password;
+    return if $self->{logged_in};
 
     $self->{ua}->credentials( "$self->{hostname}:$self->{port}",
-        "Icinga 2", $self->{username}, $self->{password} );
+        "Icinga 2", $username, $password );
 
     $self->do_request( "GET", "/status", "", "" );
 

--- a/SU/API/Icinga2.pod
+++ b/SU/API/Icinga2.pod
@@ -9,42 +9,35 @@ SU::API::Icinga2
 
     use SU::API::Icinga2;
 
-    my $icinga = new SU::API::Icinga2("fqdn","port","path","version");
+    my $icinga = new SU::API::Icinga2("fqdn",
+	port => $port,
+	path => $path,
+	version => $version,
+	cacert => $cacert_file,
+    );
     $icinga->login("username","password") or die $icinga->login_status;
 
     my $host_object = {
-                        'attrs' => {
-                                     'address'       => "127.0.0.1",
-                                     'check_command' => "hostalive"
-                                   }
-                       };
+	attrs => {
+	    address => "127.0.0.1",
+            check_command => "hostalive"
+        }
+    };
 
 
     my $put_result = $icinga->do_request("PUT", "/objects/hosts/localhost.example.com", "", $host_object);
-    if (!$put_result) {
-        warn $icinga->request_code;
-        warn $icinga->request_status_line;
-    };
-    
+        or warn sprintf("%s: %s", $icinga->request_code, $icinga->request_status_line);
+
     my $post_result = $icinga->do_request("POST", "/objects/hosts/localhost.example.com", "",$host_object);
-    if (!$post_result) {
-        warn $icinga->request_code;
-        warn $icinga->request_status_line;
-    };
+        or warn sprintf("%s: %s", $icinga->request_code, $icinga->request_status_line);
 
     my $get_result = $icinga->do_request("GET", "/objects/hosts/localhost.example.com");
-    if (!$get_result) {
-        warn $icinga->request_code;
-        warn $icinga->request_status_line;
-    };
+        or warn sprintf("%s: %s", $icinga->request_code, $icinga->request_status_line);
 
     my $delete_result = $icinga->do_request("DELETE", "/objects/hosts/localhost.example.com");
-    if (!$delete_result) {
-        warn $icinga->request_code;
-        warn $icinga->request_status_line;
-    };
+        or warn sprintf("%s: %s", $icinga->request_code, $icinga->request_status_line);
 
-    $icinga->logout();
+    $icinga->logout;
 
 =head1 DESCRIPTION
 
@@ -54,15 +47,50 @@ Module used to integrate with the REST API that Icinga2 provides.
 
 =over
 
-=item new (FQDN, PORT, PATH, VERSION, INSECURE)
+=item new (FQDN, [ tags ])
+
+=item new (FQDN, PORT, PATH, VERSION, [ INSECURE ])
 
 Returns a new SU::API::Icinga object.
 
-"PATH" is the URI where to find the API. Usually "/".
+The former calling convention with four mandatory arguments is the old one. If a
+port number is present after the Icinga host, the constructor assumes you want
+this form. The arguments are:
 
-"VERSION" should be set to the API version. Usually "1".
+=over
 
-"INSECURE" is optional and makes this module skip certificate verification if set.
+=item * FQDN is your Icinga monitoring host.
+
+=item * PORT is the port the REST API runs on.
+
+=item * PATH is the URI where to find the API, usually "/".
+
+=item * VERSION should be set to the API version, usually 1.
+
+=item * INSECURE is optional and makes this module skip certificate verification if set.
+
+=back
+
+The latter form treats only the FQDN as mandatory and allows all other arguments
+to be passed hash style with the following keys:
+
+=over
+
+=item * C<port> see above; defaults to C<5665>.
+
+=item * C<path> see above; defaults to C</>.
+
+=item * C<version> see above; defaults to 1 and is therefore completely
+redundant as long as there is only one API version.
+
+=item * C<insecure> see above; defaults to false
+
+=item * C<cacert> The file name of a PEM-format file containing the certificate
+of the CA that issued the server's HTTPS certificate. As internal monitoring
+servers often use certs from in-house CAs, this still allows for secure peer
+identification instead of using insecure mode.
+
+=back
 
 =back
 
@@ -72,12 +100,13 @@ Returns a new SU::API::Icinga object.
 
 =item login (USERNAME, PASSWORD)
 
-Configure and validate credantials. Please note that user needs at least the permission
-"status/query"
+Configures and validates credentials. Please note that user needs at least the permission
+"status/query". This methos does nothing if it has been called on the sameobject
+before unless L</logout> was called before.
 
 =item logout
 
-Destroy the login session.
+Destroys the login session.
 
 =item login_status
 
@@ -89,7 +118,7 @@ Returns true when logged in, otherwise returns undef.
 
 =item do_request (HTTP METHOD, URI, PARAMS, DATA)
 
-Perform the actual request.
+Performs the actual request.
 
 "PARAMS" is optional and can be any parameters that the Icinga API supports.
 
@@ -160,3 +189,4 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Johan Carlquist <jocar@su.se>,
 Mikael Nordin <mikael.nordin@su.se>
+Bits and pieces by Matthias Bethke <matthias@towiski.de>


### PR DESCRIPTION
So I came across this module looking for a sane way to speak to Icinga2. Cool thing, but it didn't work for me. Turns out that the `ssl_options` work with `Net::SSL` but newer LWP versions use `IO::Socket::SSL`.
I fixed that and "insecure" mode worked -- hope I didn't break it for `Net::SSL`, that I didn't test.

Then I added a module version because modules should have one in case you change things :)

Thing is, insecure mode is insecure. I wanted to be able to pass in a CA certificate to be able to actually verify our in-house certificate, but the constructor has quite enough arguments already. So I added a backwards-compatible calling convention: the hostname is mandatory but all the other arguments are optional. If a third argument (including `$class`) is present and doesn't look like a port number, it's taken to be the start of a hash-style argument list, so you can do something like `SU::API::Icinga2->new("icinga.blah.tld", cacert => "myca.crt", port => 1234);`. Arguments have defaults, like 5665 for `port` and '/' for `path`, and can come in any order.

Stuff that's not needed in other methods such as `path` isn't stored in the object any more.
I'm not sure what `export()` is for, I've never used it, but it can be simplified quite alot with the help of a static hash. So can `encode_params()` -- it doesn't matter whether a string you split contains the split character; if it doesn't, you just get the original string back.

As it is, it requires Perl 5.10.1 now because I'm lazy and like the `//` operator. If you guys happen to need this on something ready for the hospice like CentOS 5 (I feel you, we're just getting rid of it at $WORKPLACE) that would be easy to fix.

Finally, would you mind if I put this on CPAN, or would you want to? There is a "Monitoring" namespace already, `Monitoring::Icinga` exists so `Monitoring::Icinga2::Client::REST` would do, I guess. People scoff at "API", every module is an API, so that doesn't say anything, thus no API in names.