### PR TITLE
Fix export name for downtimes

### DIFF
--- a/lib/Monitoring/Icinga2/Client/REST.pm
+++ b/lib/Monitoring/Icinga2/Client/REST.pm
@@ -114,7 +114,7 @@ sub _encode_param {
         ],
         Downtime => [
             [ qw/ author comment duration end_time entry_time fixed
-                host_name service_name start_time triggers /
+                host_name service_name start_time vars triggers /
             ],
             [ qw/ templates zone / ],
         ],


### PR DESCRIPTION
We need vars for all objects since __export_name is stored there